### PR TITLE
Add TMDB backtrace fallback via Bangumi prequels

### DIFF
--- a/cmd/animego/main.go
+++ b/cmd/animego/main.go
@@ -175,8 +175,9 @@ func Main() {
 		CacheTime: int64(config.Advanced.Cache.MikanCacheHour * 60 * 60),
 	}
 	tmdbOpts := &themoviedb.Options{
-		Cache:     bolt,
-		CacheTime: int64(config.Advanced.Cache.ThemoviedbCacheHour * 60 * 60),
+		Cache:           bolt,
+		CacheTime:       int64(config.Advanced.Cache.ThemoviedbCacheHour * 60 * 60),
+		EnableBacktrace: config.Default.TMDBFailBacktrace,
 	}
 	// ===============================================================================================================
 	// 初始化插件 gpython
@@ -269,6 +270,7 @@ func Main() {
 	filterSrv := wire.GetFilter(&models.FilterOptions{
 		DelaySecond: config.Advanced.Feed.DelaySecond,
 	}, downloaderSrv, &models.ParserOptions{
+		TMDBFailBacktrace:      config.Default.TMDBFailBacktrace,
 		TMDBFailSkip:           config.Default.TMDBFailSkip,
 		TMDBFailUseTitleSeason: config.Default.TMDBFailUseTitleSeason,
 		TMDBFailUseFirstSeason: config.Default.TMDBFailUseFirstSeason,

--- a/configs/default.go
+++ b/configs/default.go
@@ -128,6 +128,7 @@ func defaultAdvanced() {
 	defaultConfig.Advanced.Feed.DelaySecond = 5
 
 	defaultConfig.Advanced.Default.TMDBFailSkip = false
+	defaultConfig.Advanced.Default.TMDBFailBacktrace = true
 	defaultConfig.Advanced.Default.TMDBFailUseTitleSeason = true
 	defaultConfig.Advanced.Default.TMDBFailUseFirstSeason = true
 

--- a/configs/models.go
+++ b/configs/models.go
@@ -80,7 +80,8 @@ type Advanced struct {
 	} `yaml:"feed" json:"feed" attr:"订阅设置"`
 
 	Default struct {
-		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip" attr:"跳过当前项" comment:"tmdb解析季度失败时，跳过当前项。优先级3"`
+		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip" attr:"跳过当前项" comment:"tmdb解析季度失败时，跳过当前项。优先级4"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace" attr:"季度回溯匹配" comment:"tmdb解析季度失败时，季度逐个回溯匹配直到有匹配选项。优先级3"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season" attr:"文件名解析季度" comment:"tmdb解析季度失败时，从文件名中获取季度信息。优先级2"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season" attr:"使用第一季" comment:"tmdb解析季度失败时，默认使用第一季。优先级1"`
 	} `yaml:"default" json:"default" attr:"解析季度默认值" comment:"使用tmdb解析季度失败时，同类型默认值按优先级执行。数值越大，优先级越高"`

--- a/configs/update.go
+++ b/configs/update.go
@@ -520,6 +520,7 @@ func update_170_171(old, new any, version string) {
 	newConfig.Advanced.Source.Themoviedb.Redirect = oldConfig.Advanced.AniData.Themoviedb.Redirect
 	log.Println("[变动] 配置项(setting.key.themoviedb) 变更为 advanced.source.themoviedb.api_key")
 	newConfig.Advanced.Source.Themoviedb.ApiKey = oldConfig.Setting.Key.Themoviedb
+	newConfig.Advanced.Default.TMDBFailBacktrace = true
 
 	// 强制写入
 	assets.WritePlugins(assets.Dir, path.Join(newConfig.DataPath, assets.Dir), false)

--- a/configs/version/v_110/models.go
+++ b/configs/version/v_110/models.go
@@ -75,6 +75,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_120/models.go
+++ b/configs/version/v_120/models.go
@@ -75,6 +75,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_130/models.go
+++ b/configs/version/v_130/models.go
@@ -79,6 +79,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_140/models.go
+++ b/configs/version/v_140/models.go
@@ -74,6 +74,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_141/models.go
+++ b/configs/version/v_141/models.go
@@ -71,6 +71,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_150/models.go
+++ b/configs/version/v_150/models.go
@@ -71,6 +71,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_151/models.go
+++ b/configs/version/v_151/models.go
@@ -71,6 +71,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_152/models.go
+++ b/configs/version/v_152/models.go
@@ -78,6 +78,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_160/models.go
+++ b/configs/version/v_160/models.go
@@ -78,6 +78,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_161/models.go
+++ b/configs/version/v_161/models.go
@@ -85,6 +85,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_162/models.go
+++ b/configs/version/v_162/models.go
@@ -85,6 +85,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/configs/version/v_170/models.go
+++ b/configs/version/v_170/models.go
@@ -83,6 +83,7 @@ type Advanced struct {
 
 	Default struct {
 		TMDBFailSkip           bool `yaml:"tmdb_fail_skip" json:"tmdb_fail_skip"`
+		TMDBFailBacktrace      bool `yaml:"tmdb_fail_backtrace" json:"tmdb_fail_backtrace"`
 		TMDBFailUseTitleSeason bool `yaml:"tmdb_fail_use_title_season" json:"tmdb_fail_use_title_season"`
 		TMDBFailUseFirstSeason bool `yaml:"tmdb_fail_use_first_season" json:"tmdb_fail_use_first_season"`
 	} `yaml:"default" json:"default"`

--- a/internal/animego/anisource/anisource_test.go
+++ b/internal/animego/anisource/anisource_test.go
@@ -61,8 +61,9 @@ func TestMain(m *testing.M) {
 		BangumiCache:     bangumiCache,
 		BangumiCacheLock: &mutex,
 	}, &themoviedb.Options{
-		Cache:     b,
-		CacheTime: int64(7 * 24 * 60 * 60),
+		Cache:           b,
+		CacheTime:       int64(7 * 24 * 60 * 60),
+		EnableBacktrace: true,
 	})
 
 	bangumiHost := test.MockBangumiStart(ctx)

--- a/internal/animego/anisource/bangumi.go
+++ b/internal/animego/anisource/bangumi.go
@@ -66,16 +66,20 @@ func (m Bangumi) Parse(opts *models.AnimeParseOptions) (anime *models.AnimeEntit
 	// ------------------- 获取tmdb信息(季度信息) -------------------
 	if opts.AnimeParseOverride == nil || !opts.OverrideThemoviedb() {
 		log.Debugf("[AniSource] 解析Themoviedb，%s, %s", bgmEntity.Name, bgmEntity.AirDate)
-		id, err := m.themoviedb.SearchCache(bgmEntity.Name, nil)
+		id, err := m.themoviedb.SearchCache(bgmEntity.Name, &themoviedb.SearchFilters{BangumiID: bgmID})
 		if err != nil {
 			return nil, err
 		}
 		tmdbID = id
-		entity, err := m.themoviedb.GetCache(id, bgmEntity.AirDate)
+		entity, err := m.themoviedb.GetCache(id, &themoviedb.SeasonFilters{AirDate: bgmEntity.AirDate, BangumiID: bgmID})
 		if err != nil {
 			log.Warnf("[AniSource] 解析Themoviedb获取番剧季度信息失败")
 		} else {
-			season = entity.(*themoviedb.SeasonInfo).Season
+			info := entity.(*themoviedb.SeasonInfo)
+			season = info.Season
+			if info.ShowID != 0 && info.ShowID != tmdbID {
+				tmdbID = info.ShowID
+			}
 		}
 	} else {
 		tmdbID = opts.AnimeParseOverride.ThemoviedbID

--- a/internal/animego/anisource/themoviedb/models.go
+++ b/internal/animego/anisource/themoviedb/models.go
@@ -3,8 +3,9 @@ package themoviedb
 import mem "github.com/wetor/AnimeGo/pkg/memorizer"
 
 type Options struct {
-	Cache     mem.Memorizer
-	CacheTime int64
+	Cache           mem.Memorizer
+	CacheTime       int64
+	EnableBacktrace bool
 }
 
 type Entity struct {
@@ -29,6 +30,7 @@ type SeasonInfo struct {
 	EpName  string `json:"name"`
 	Ep      int    `json:"episode_number"`
 	Eps     int    `json:"episode_count"`
+	ShowID  int    `json:"-"`
 }
 
 type InfoResponse struct {
@@ -40,4 +42,13 @@ type InfoResponse struct {
 	NumberOfSeasons  int           `json:"number_of_seasons"`
 	OriginalName     string        `json:"original_name"`
 	Seasons          []*SeasonInfo `json:"seasons"`
+}
+
+type SearchFilters struct {
+	BangumiID int
+}
+
+type SeasonFilters struct {
+	AirDate   string
+	BangumiID int
 }

--- a/internal/animego/anisource/themoviedb/themoviedb.go
+++ b/internal/animego/anisource/themoviedb/themoviedb.go
@@ -1,6 +1,9 @@
 package themoviedb
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/google/wire"
 	"github.com/pkg/errors"
 
@@ -8,6 +11,7 @@ import (
 	"github.com/wetor/AnimeGo/internal/constant"
 	"github.com/wetor/AnimeGo/internal/exceptions"
 	"github.com/wetor/AnimeGo/internal/pkg/request"
+	pkgExceptions "github.com/wetor/AnimeGo/pkg/exceptions"
 	"github.com/wetor/AnimeGo/pkg/log"
 	mem "github.com/wetor/AnimeGo/pkg/memorizer"
 	"github.com/wetor/AnimeGo/pkg/utils"
@@ -25,6 +29,10 @@ var Set = wire.NewSet(
 	NewThemoviedb,
 )
 
+var bangumiSubjectApi = func(id int) string {
+	return fmt.Sprintf("%s/v0/subjects/%d/subjects", constant.BangumiHost, id)
+}
+
 func NewThemoviedb(opts *Options) *Themoviedb {
 	return &Themoviedb{
 		Options: opts,
@@ -39,7 +47,11 @@ func (a *Themoviedb) RegisterCache() {
 	a.cacheInit = true
 	a.cacheParseThemoviedbID = mem.Memorized(constant.ThemoviedbBucket, a.Cache.(mem.Memorizer),
 		func(params *mem.Params, results *mem.Results) error {
-			entity, err := a.parseThemoviedbID(params.Get("name").(string))
+			bangumiID := 0
+			if v := params.Get("bangumi_id"); v != nil {
+				bangumiID = v.(int)
+			}
+			entity, err := a.parseThemoviedbID(params.Get("name").(string), bangumiID)
 			if err != nil {
 				return err
 			}
@@ -49,7 +61,11 @@ func (a *Themoviedb) RegisterCache() {
 
 	a.cacheParseAnimeSeason = mem.Memorized(constant.ThemoviedbBucket, a.Cache.(mem.Memorizer),
 		func(params *mem.Params, results *mem.Results) error {
-			seasonInfo, err := a.parseAnimeSeason(params.Get("tmdbID").(int), params.Get("airDate").(string))
+			bangumiID := 0
+			if v := params.Get("bangumi_id"); v != nil {
+				bangumiID = v.(int)
+			}
+			seasonInfo, err := a.parseAnimeSeason(params.Get("tmdbID").(int), params.Get("airDate").(string), bangumiID)
 			if err != nil {
 				return err
 			}
@@ -59,7 +75,7 @@ func (a *Themoviedb) RegisterCache() {
 }
 
 func (a *Themoviedb) Search(name string, filters any) (int, error) {
-	entity, err := a.parseThemoviedbID(name)
+	entity, err := a.parseThemoviedbID(name, getBangumiID(filters))
 	if err != nil {
 		return 0, errors.Wrap(err, "查询ThemoviedbID失败")
 	}
@@ -71,7 +87,8 @@ func (a *Themoviedb) SearchCache(name string, filters any) (int, error) {
 		a.RegisterCache()
 	}
 	results := mem.NewResults("entity", &Entity{})
-	err := a.cacheParseThemoviedbID(mem.NewParams("name", name).
+	params := mem.NewParams("name", name, "bangumi_id", getBangumiID(filters))
+	err := a.cacheParseThemoviedbID(params.
 		TTL(a.CacheTime), results)
 	if err != nil {
 		return 0, errors.Wrap(err, "查询ThemoviedbID失败")
@@ -81,8 +98,8 @@ func (a *Themoviedb) SearchCache(name string, filters any) (int, error) {
 }
 
 func (a *Themoviedb) Get(id int, filters any) (any, error) {
-	airDate := filters.(string)
-	seasonInfo, err := a.parseAnimeSeason(id, airDate)
+	seasonFilters := parseSeasonFilters(filters)
+	seasonInfo, err := a.parseAnimeSeason(id, seasonFilters.AirDate, seasonFilters.BangumiID)
 	if err != nil {
 		return nil, errors.Wrap(err, "获取Themoviedb信息失败")
 	}
@@ -93,9 +110,9 @@ func (a *Themoviedb) GetCache(id int, filters any) (any, error) {
 	if !a.cacheInit {
 		a.RegisterCache()
 	}
-	airDate := filters.(string)
+	seasonFilters := parseSeasonFilters(filters)
 	results := mem.NewResults("seasonInfo", &SeasonInfo{})
-	err := a.cacheParseAnimeSeason(mem.NewParams("tmdbID", id, "airDate", airDate).
+	err := a.cacheParseAnimeSeason(mem.NewParams("tmdbID", id, "airDate", seasonFilters.AirDate, "bangumi_id", seasonFilters.BangumiID).
 		TTL(a.CacheTime), results)
 	if err != nil {
 		return nil, errors.Wrap(err, "获取Themoviedb信息失败")
@@ -104,26 +121,213 @@ func (a *Themoviedb) GetCache(id int, filters any) (any, error) {
 	return seasonInfo, nil
 }
 
-func (a *Themoviedb) parseThemoviedbID(name string) (entity *Entity, err error) {
+func (a *Themoviedb) parseThemoviedbID(name string, bangumiID int) (entity *Entity, err error) {
+	entity, err = a.parseThemoviedbIDWithVisited([]string{name}, bangumiID, nil)
+	if err != nil {
+		switch errors.Cause(err).(type) {
+		case *exceptions.ErrThemoviedbMatchSeason:
+			return nil, err
+		default:
+			if isThemoviedbParseError(err) {
+				return nil, &exceptions.ErrThemoviedbSearchName{}
+			}
+			return nil, err
+		}
+	}
+	return entity, nil
+}
+
+func (a *Themoviedb) parseAnimeSeason(tmdbID int, airDate string, bangumiID int) (seasonInfo *SeasonInfo, err error) {
+	return a.parseAnimeSeasonWithVisited(tmdbID, airDate, bangumiID, nil)
+}
+
+type bangumiSubjectRelation struct {
+	ID     int
+	Name   string
+	NameCN string
+}
+
+func (a *Themoviedb) parseThemoviedbIDWithVisited(names []string, bangumiID int, visited map[int]struct{}) (*Entity, error) {
+	if visited == nil {
+		visited = make(map[int]struct{})
+	} else {
+		visited = copyVisited(visited)
+	}
+	if bangumiID > 0 {
+		if _, ok := visited[bangumiID]; ok {
+			return nil, &pkgExceptions.ErrRemoveNameSuffix{}
+		}
+		visited[bangumiID] = struct{}{}
+	}
+
+	var lastErr error
+	for _, name := range uniqueNames(names) {
+		entity, err := a.searchThemoviedbID(name)
+		if err != nil {
+			if isThemoviedbParseError(err) {
+				lastErr = err
+				continue
+			}
+			return nil, err
+		}
+		if entity != nil {
+			return entity, nil
+		}
+	}
+
+	if !a.EnableBacktrace || bangumiID <= 0 {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, &pkgExceptions.ErrRemoveNameSuffix{}
+	}
+
+	prequels, err := a.fetchBangumiPrequelSubjects(bangumiID)
+	if err != nil {
+		log.DebugErr(err)
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, &pkgExceptions.ErrRemoveNameSuffix{}
+	}
+
+	for _, prequel := range prequels {
+		entity, err := a.parseThemoviedbIDWithVisited([]string{prequel.NameCN, prequel.Name}, prequel.ID, visited)
+		if err != nil {
+			if isThemoviedbParseError(err) {
+				lastErr = err
+				continue
+			}
+			return nil, err
+		}
+		if entity != nil {
+			return entity, nil
+		}
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, &pkgExceptions.ErrRemoveNameSuffix{}
+}
+
+func (a *Themoviedb) parseAnimeSeasonWithVisited(tmdbID int, airDate string, bangumiID int, visited map[int]struct{}) (*SeasonInfo, error) {
+	if visited == nil {
+		visited = make(map[int]struct{})
+	} else {
+		visited = copyVisited(visited)
+	}
+	if bangumiID > 0 {
+		if _, ok := visited[bangumiID]; ok {
+			err := errors.WithStack(&exceptions.ErrThemoviedbMatchSeason{Message: "此番剧可能未开播"})
+			log.DebugErr(err)
+			return nil, err
+		}
+		visited[bangumiID] = struct{}{}
+	}
+
+	resp := InfoResponse{}
+	err := request.Get(infoApi(tmdbID, false), &resp)
+	if err != nil {
+		log.DebugErr(err)
+		return nil, errors.WithStack(&exceptions.ErrRequest{Name: a.Name()})
+	}
+	if resp.Seasons == nil || len(resp.Seasons) == 0 {
+		err = errors.WithStack(&exceptions.ErrThemoviedbMatchSeason{Message: "此番剧可能未开播"})
+		log.DebugErr(err)
+		return nil, err
+	}
+	seasonInfo := resp.Seasons[0]
+	min := 36500
+	for _, r := range resp.Seasons {
+		if r.Season == 0 || r.EpName == "Specials" {
+			continue
+		}
+		if s := StrTimeSubAbs(r.AirDate, airDate); s < min {
+			min = s
+			seasonInfo = r
+		}
+	}
+	seasonInfo.ShowID = tmdbID
+	if min <= constant.ThemoviedbMatchSeasonDays {
+		seasonInfo.EpName = ""
+		return seasonInfo, nil
+	}
+
+	matchErr := errors.WithStack(&exceptions.ErrThemoviedbMatchSeason{Message: "此番剧可能未开播"})
+	log.DebugErr(matchErr)
+	if !a.EnableBacktrace || bangumiID <= 0 {
+		return nil, matchErr
+	}
+
+	prequels, fetchErr := a.fetchBangumiPrequelSubjects(bangumiID)
+	if fetchErr != nil {
+		log.DebugErr(fetchErr)
+		return nil, matchErr
+	}
+	if len(prequels) == 0 {
+		return nil, matchErr
+	}
+
+	for _, prequel := range prequels {
+		if _, ok := visited[prequel.ID]; ok {
+			continue
+		}
+		nextVisited := copyVisited(visited)
+		nextVisited[prequel.ID] = struct{}{}
+
+		candidates := uniqueNames([]string{prequel.NameCN, prequel.Name})
+		var entity *Entity
+		for _, candidate := range candidates {
+			e, err := a.parseThemoviedbID(candidate, prequel.ID)
+			if err != nil {
+				if isThemoviedbParseError(err) {
+					continue
+				}
+				return nil, err
+			}
+			if e != nil {
+				entity = e
+				break
+			}
+		}
+		if entity == nil {
+			continue
+		}
+
+		info, err := a.parseAnimeSeasonWithVisited(entity.ID, airDate, prequel.ID, nextVisited)
+		if err != nil {
+			if isThemoviedbParseError(err) {
+				continue
+			}
+			return nil, err
+		}
+		if info != nil {
+			return info, nil
+		}
+	}
+
+	return nil, matchErr
+}
+
+func (a *Themoviedb) searchThemoviedbID(name string) (*Entity, error) {
 	resp := FindResponse{}
 	result, err := utils.RemoveNameSuffix(name, func(innerName string) (any, error) {
+		resp = FindResponse{}
 		err := request.Get(idApi(innerName, false), &resp)
 		if err != nil {
 			log.DebugErr(err)
-			//return 0, errors.WithStack(&exceptions.ErrRequest{Name: a.Name()})
 		}
 
 		if resp.TotalResults == 1 {
 			return resp.Result[0], nil
 		} else if resp.TotalResults > 1 {
-			// 筛选与original name完全相同的番剧
 			for _, result := range resp.Result {
 				if result.Name == name {
 					return result, nil
 				}
 			}
 
-			// 按照相似度排序筛选
 			temp := &Entity{}
 			maxSimilar := float64(0)
 			for _, result := range resp.Result {
@@ -139,52 +343,125 @@ func (a *Themoviedb) parseThemoviedbID(name string) (entity *Entity, err error) 
 			err = errors.WithStack(&exceptions.ErrThemoviedbMatchSeason{Message: "番剧名未找到"})
 			log.DebugErr(err)
 			return nil, err
-		} else {
-			// 未找到结果
-			return nil, nil
 		}
+		return nil, nil
 	})
 	if err != nil {
-		if exceptions.IsParseFailed(err) {
-			return nil, &exceptions.ErrThemoviedbSearchName{}
-		} else {
-			return nil, err
-		}
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
 	}
 	return result.(*Entity), nil
 }
 
-func (a *Themoviedb) parseAnimeSeason(tmdbID int, airDate string) (seasonInfo *SeasonInfo, err error) {
-	resp := InfoResponse{}
-	err = request.Get(infoApi(tmdbID, false), &resp)
-	if err != nil {
-		log.DebugErr(err)
-		return nil, errors.WithStack(&exceptions.ErrRequest{Name: a.Name()})
+func (a *Themoviedb) fetchBangumiPrequelSubjects(bangumiID int) ([]bangumiSubjectRelation, error) {
+	if bangumiID <= 0 {
+		return nil, nil
 	}
-	if resp.Seasons == nil || len(resp.Seasons) == 0 {
-		err = errors.WithStack(&exceptions.ErrThemoviedbMatchSeason{Message: "此番剧可能未开播"})
-		log.DebugErr(err)
+	resp := make([]struct {
+		Name     string `json:"name"`
+		NameCN   string `json:"name_cn"`
+		Relation string `json:"relation"`
+		ID       int    `json:"id"`
+	}, 0)
+	err := request.Get(bangumiSubjectApi(bangumiID), &resp)
+	if err != nil {
 		return nil, err
 	}
-	seasonInfo = resp.Seasons[0]
-	min := 36500
-	for _, r := range resp.Seasons {
-		if r.Season == 0 || r.EpName == "Specials" {
+	subjects := make([]bangumiSubjectRelation, 0, len(resp))
+	for _, item := range resp {
+		if item.Relation != "前传" {
 			continue
 		}
-		// TODO: 待优化，通过比较此季度番剧的初放送日期，筛选差值最小的季
-		if s := StrTimeSubAbs(r.AirDate, airDate); s < min {
-			min = s
-			seasonInfo = r
+		subjects = append(subjects, bangumiSubjectRelation{
+			ID:     item.ID,
+			Name:   item.Name,
+			NameCN: item.NameCN,
+		})
+	}
+	return subjects, nil
+}
+
+func getBangumiID(filters any) int {
+	if filters == nil {
+		return 0
+	}
+	switch v := filters.(type) {
+	case *SearchFilters:
+		if v != nil {
+			return v.BangumiID
 		}
+	case SearchFilters:
+		return v.BangumiID
+	case *SeasonFilters:
+		if v != nil {
+			return v.BangumiID
+		}
+	case SeasonFilters:
+		return v.BangumiID
+	case int:
+		return v
 	}
-	if min > constant.ThemoviedbMatchSeasonDays {
-		err = errors.WithStack(&exceptions.ErrThemoviedbMatchSeason{Message: "此番剧可能未开播"})
-		log.DebugErr(err)
-		return nil, err
+	return 0
+}
+
+func parseSeasonFilters(filters any) *SeasonFilters {
+	switch v := filters.(type) {
+	case *SeasonFilters:
+		if v != nil {
+			return v
+		}
+	case SeasonFilters:
+		return &SeasonFilters{AirDate: v.AirDate, BangumiID: v.BangumiID}
+	case string:
+		return &SeasonFilters{AirDate: v}
 	}
-	seasonInfo.EpName = ""
-	return seasonInfo, nil
+	return &SeasonFilters{}
+}
+
+func uniqueNames(names []string) []string {
+	result := make([]string, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if len(name) == 0 {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	return result
+}
+
+func copyVisited(src map[int]struct{}) map[int]struct{} {
+	if src == nil {
+		return make(map[int]struct{})
+	}
+	dst := make(map[int]struct{}, len(src))
+	for k := range src {
+		dst[k] = struct{}{}
+	}
+	return dst
+}
+
+func isThemoviedbParseError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if exceptions.IsParseFailed(err) {
+		return true
+	}
+	switch errors.Cause(err).(type) {
+	case *exceptions.ErrThemoviedbMatchSeason:
+		return true
+	case *exceptions.ErrThemoviedbSearchName:
+		return true
+	}
+	return false
 }
 
 // Check interface is satisfied

--- a/internal/animego/anisource/themoviedb/themoviedb_test.go
+++ b/internal/animego/anisource/themoviedb/themoviedb_test.go
@@ -32,7 +32,8 @@ func TestMain(m *testing.M) {
 	db := cache.NewBolt()
 	db.Open("data/bolt.db")
 	tmdbInst = themoviedb.NewThemoviedb(&themoviedb.Options{
-		Cache: db,
+		Cache:           db,
+		EnableBacktrace: true,
 	})
 	host := test.MockThemoviedbStart(ctx)
 	request.Init(&request.Options{
@@ -74,37 +75,37 @@ func TestThemoviedb_Get_GetCache(t *testing.T) {
 			name:           "海贼王",
 			args:           args{name: "ONE PIECE", airDate: "1999-10-20"},
 			wantID:         37854,
-			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 1, AirDate: "1999-10-20", EpID: 49188, EpName: "", Ep: 0, Eps: 61},
+			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 1, AirDate: "1999-10-20", EpID: 49188, EpName: "", Ep: 0, Eps: 61, ShowID: 37854},
 		},
 		{
 			name:           "在地下城寻求邂逅是否搞错了什么 Ⅳ 新章 迷宫篇",
 			args:           args{name: "ダンジョンに出会いを求めるのは間違っているだろうか Ⅳ 新章 迷宮篇", airDate: "2022-07-21"},
 			wantID:         62745,
-			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 4, AirDate: "2022-07-23", EpID: 193725, EpName: "", Ep: 0, Eps: 22},
+			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 4, AirDate: "2022-07-23", EpID: 193725, EpName: "", Ep: 0, Eps: 22, ShowID: 62745},
 		},
 		{
 			name:           "来自深渊 烈日的黄金乡",
 			args:           args{name: "メイドインアビス 烈日の黄金郷", airDate: "2022-07-06"},
 			wantID:         72636,
-			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 2, AirDate: "2022-07-06", EpID: 204984, EpName: "", Ep: 0, Eps: 12},
+			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 2, AirDate: "2022-07-06", EpID: 204984, EpName: "", Ep: 0, Eps: 12, ShowID: 72636},
 		},
 		{
 			name:           "OVERLORD IV",
 			args:           args{name: "オーバーロードIV", airDate: "2022-07-05"},
 			wantID:         64196,
-			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 4, AirDate: "2022-07-05", EpID: 194087, EpName: "", Ep: 0, Eps: 13},
+			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 4, AirDate: "2022-07-05", EpID: 194087, EpName: "", Ep: 0, Eps: 13, ShowID: 64196},
 		},
 		{
 			name:           "福星小子",
 			args:           args{name: "うる星やつら", airDate: "2022-10-14"},
 			wantID:         154524,
-			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 1, AirDate: "2022-10-14", EpID: 237892, EpName: "", Ep: 0, Eps: 46},
+			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 1, AirDate: "2022-10-14", EpID: 237892, EpName: "", Ep: 0, Eps: 46, ShowID: 154524},
 		},
 		{
 			name:           "Mairimashita! Iruma-kun 3rd Season",
 			args:           args{name: "Mairimashita! Iruma-kun 3rd Season", airDate: "2022-11-14"},
 			wantID:         91801,
-			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 3, AirDate: "2022-10-08", EpID: 306624, EpName: "", Ep: 0, Eps: 21},
+			wantSeasonInfo: &themoviedb.SeasonInfo{Season: 3, AirDate: "2022-10-08", EpID: 306624, EpName: "", Ep: 0, Eps: 21, ShowID: 91801},
 		},
 		{
 			name:        "err_search_not_found",

--- a/internal/animego/parser/parser_test.go
+++ b/internal/animego/parser/parser_test.go
@@ -80,6 +80,7 @@ func TestMain(m *testing.M) {
 	test.HookMethod(bangumiSource, "Parse", BangumiParse)
 
 	mgr = parser.NewManager(&models.ParserOptions{
+		TMDBFailBacktrace:      true,
 		TMDBFailSkip:           false,
 		TMDBFailUseTitleSeason: true,
 		TMDBFailUseFirstSeason: true,

--- a/internal/models/option.go
+++ b/internal/models/option.go
@@ -84,6 +84,7 @@ type FilterOptions struct {
 }
 
 type ParserOptions struct {
+	TMDBFailBacktrace      bool
 	TMDBFailSkip           bool
 	TMDBFailUseTitleSeason bool
 	TMDBFailUseFirstSeason bool

--- a/test/testdata/config/animego_110.yaml
+++ b/test/testdata/config/animego_110.yaml
@@ -51,6 +51,7 @@ advanced:
         temp_path: temp
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_120.yaml
+++ b/test/testdata/config/animego_120.yaml
@@ -53,6 +53,7 @@ advanced:
             goroutine_max: 4
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_130.yaml
+++ b/test/testdata/config/animego_130.yaml
@@ -49,6 +49,7 @@ advanced:
             goroutine_max: 4
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_140.yaml
+++ b/test/testdata/config/animego_140.yaml
@@ -54,6 +54,7 @@ advanced:
             goroutine_max: 4
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_141.yaml
+++ b/test/testdata/config/animego_141.yaml
@@ -57,6 +57,7 @@ advanced:
         delay_second: 2
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_150.yaml
+++ b/test/testdata/config/animego_150.yaml
@@ -55,6 +55,7 @@ advanced:
         delay_second: 2
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_151.yaml
+++ b/test/testdata/config/animego_151.yaml
@@ -55,6 +55,7 @@ advanced:
         delay_second: 2
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_152.yaml
+++ b/test/testdata/config/animego_152.yaml
@@ -60,6 +60,7 @@ advanced:
         delay_second: 2
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_160.yaml
+++ b/test/testdata/config/animego_160.yaml
@@ -60,6 +60,7 @@ advanced:
         delay_second: 2
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_161.yaml
+++ b/test/testdata/config/animego_161.yaml
@@ -64,6 +64,7 @@ advanced:
         delay_second: 2
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_162.yaml
+++ b/test/testdata/config/animego_162.yaml
@@ -64,6 +64,7 @@ advanced:
         delay_second: 2
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_170.yaml
+++ b/test/testdata/config/animego_170.yaml
@@ -63,6 +63,7 @@ advanced:
         delay_second: 2
     default:
         tmdb_fail_skip: false
+        tmdb_fail_backtrace: false
         tmdb_fail_use_title_season: true
         tmdb_fail_use_first_season: true
     client:

--- a/test/testdata/config/animego_171.yaml
+++ b/test/testdata/config/animego_171.yaml
@@ -125,8 +125,10 @@ advanced:
         delay_second: 2
     # 解析季度默认值. 使用tmdb解析季度失败时，同类型默认值按优先级执行。数值越大，优先级越高
     default:
-        # 跳过当前项. tmdb解析季度失败时，跳过当前项。优先级3
+        # 跳过当前项. tmdb解析季度失败时，跳过当前项。优先级4
         tmdb_fail_skip: false
+        # 季度回溯匹配. tmdb解析季度失败时，季度逐个回溯匹配直到有匹配选项。优先级3
+        tmdb_fail_backtrace: true
         # 文件名解析季度. tmdb解析季度失败时，从文件名中获取季度信息。优先级2
         tmdb_fail_use_title_season: true
         # 使用第一季. tmdb解析季度失败时，默认使用第一季。优先级1


### PR DESCRIPTION
## Summary
- add Bangumi prequel-based backtrace when TMDB season matching fails and wire the new option into parser/CLI
- surface a TMDBFailBacktrace config flag with defaults, migrations and updated fixtures
- ensure TMDB parser skips cycles via visited sets and preserves legacy error mapping

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cbb40691ac8329bb54343f4dc7b052